### PR TITLE
Feature: Kubernetes introspection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM rockylinux:8
 #
 ARG ARCH="amd64"
 ARG OS="linux"
-ARG VER="1.0.1"
+ARG VER="1.0.2"
 ARG PKG="nettest"
 ARG UID="0"
 
@@ -21,28 +21,29 @@ LABEL IMAGE_SOURCE="https://github.com/ArkCase/ark_nettest"
 #
 # Full update
 #
+COPY kubernetes.repo /etc/yum.repos.d/
 RUN yum -y install epel-release && \
     yum -y update && \
     yum -y install yum-utils which && \
     yum-config-manager \
         --enable devel \
-        --enable powertools
-
-RUN yum -y install \
+        --enable powertools && \
+    yum -y install \
         bind-utils \
         jq \
+        kubectl \
         nc \
         net-tools \
         nmap \
         openldap-clients \
         telnet \
         vim \
-        wget
-
-COPY entrypoint /
+        wget && \
+    yum -y clean all
 
 #
 # Final parameters
 #
 WORKDIR     /
-ENTRYPOINT  [ "/entrypoint" ]
+USER        "${UID}"
+ENTRYPOINT  [ "sleep", "infinity" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN yum -y install epel-release && \
         wget && \
     yum -y clean all
 
+COPY nettest.yaml /
+
 #
 # Final parameters
 #

--- a/entrypoint
+++ b/entrypoint
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec sleep infinity

--- a/kubernetes.repo
+++ b/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+#exclude=kubelet kubeadm kubectl

--- a/nettest.yaml
+++ b/nettest.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nettest
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nettest
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - pods
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nettest
+subjects:
+  - kind: ServiceAccount
+    name: nettest
+roleRef:
+  kind: Role
+  name: nettest
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nettest
+spec:
+  serviceAccountName: nettest
+  containers:
+    - name: nettest
+      image: 345280441424.dkr.ecr.ap-south-1.amazonaws.com/ark_nettest:1.0.2


### PR DESCRIPTION
Modified to support K8s introspection of the namespace. Some RBAC configuration is required to allow it, but this will be useful as a debugging tool in the long run.